### PR TITLE
ci: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,15 @@ updates:
       prefix: "(GHA)"
     reviewers:
       - "UKHomeOffice/core-cloud-devops"
+    groups:
+      actions-minor:
+        update-types:
+          - 'minor'
+          - 'patch'
     labels:
       - "patch"
       - "dependencies"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -19,6 +25,16 @@ updates:
       prefix: "(NPM)"
     reviewers:
       - "UKHomeOffice/core-cloud-devops"
+    groups:
+      npm-development:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+      npm-production:
+        dependency-type: 'production'
+        update-types:
+          - 'patch'
     labels:
       - "patch"
       - "dependencies"


### PR DESCRIPTION
Add groups to dependabot to reduce the overhead of dependency overhead. This introduces one group for GitHub Actions and two for development and production NPM dependencies.